### PR TITLE
getDay() 返回一个整数值： 0 代表星期日， 1 代表星期一，2 代表星期二， 依次类推。

### DIFF
--- a/lib/rules/no-illegal-working-time.js
+++ b/lib/rules/no-illegal-working-time.js
@@ -23,7 +23,7 @@ module.exports = {
           context.report(node, "每天 18:00 之后禁止代码变更");
         }
 
-        if (dayOfWeek > 5) {
+        if (dayOfWeek === 0 || dayOfWeek === 6) {
           context.report(node, "周六周日 禁止代码变更");
         }
       }


### PR DESCRIPTION
https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay#Description